### PR TITLE
Add "baize" and "babul"

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -76,10 +76,12 @@ author
 average
 award
 awareness
+babul
 back
 background
 bad
 bag
+baize
 bake
 balance
 ball


### PR DESCRIPTION
Hey there,
I'm not really into Minecraft OG names but I found those 2 words which aren't on the LABYnet OG name (category: nouns) list and I thought they are OG.
Those are:
`baize` (*a coarse woolen or cotton fabric napped to imitate felt* ([Source](https://www.merriam-webster.com/dictionary/baize)))
`babul` (*an acacia tree (Acacia nilotica synonym A. arabica) widespread in India and northern Africa that yields gum arabic and tannins as well as fodder and timber* ([Source](https://www.merriam-webster.com/dictionary/babul))).

I hope they count as OG.
Have a great day!