### PR TITLE
Add "kahppa"

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -704,6 +704,7 @@ joke
 judgment
 juice
 jump
+kahppa
 keep
 key
 kick


### PR DESCRIPTION
"Kahppa" seems a lot like an OG name, it means a lot in different languages, and is only 6 letters long. In my opinion, I believe that if other language words like "Eriterea" and "kelkoo" count as OG, "Kahppa" (which means something in 40 different languages, use google translate to verify) should be included :)