### PR TITLE
Added the name "gericht" to words/nouns.txt

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -565,6 +565,7 @@ gas
 gate
 gather
 gear
+gericht
 gift
 girlfriend
 give


### PR DESCRIPTION
The reason for choosing this name is: the name has two different meanings in German (1st: court, 2nd: dish) and is a well known noun in the german language.