### PR TITLE
add golfed (verb)

### DIFF
--- a/src/words/verbs.txt
+++ b/src/words/verbs.txt
@@ -617,3 +617,4 @@ woke
 would
 write
 yield
+golfed


### PR DESCRIPTION
commonly used in past.
source: https://www.thefreedictionary.com/golfed