### PR TITLE
Added "Lutfi" to OG name

### DIFF
--- a/src/names/names.txt
+++ b/src/names/names.txt
@@ -1758,6 +1758,7 @@ Lukasz
 Luke
 Lupe
 Lusine
+Lutfi
 Luther
 Lutz
 Luz


### PR DESCRIPTION
 "Lutfi" is a common name in various parts of the world, especially in Muslim-majority region like Indonesia. Thats why I think this name deserve to be OG. This name also above "Luther" in the most common name in the world.
https://forebears.io/forenames/lutfi
https://en.wikipedia.org/wiki/Lutfi