### PR TITLE
Rename "Turkey" to "Turkiye"

### DIFF
--- a/src/countries/Asia.txt
+++ b/src/countries/Asia.txt
@@ -35,7 +35,7 @@ Srilanka
 Syria
 Taiwan
 Thailand
-Turkey
+Turkiye
 Turkmenistan
 UAE
 Uzbekistan


### PR DESCRIPTION
As mentioned in [Wikipedia](https://wikipedia.org/wiki/Turkey), Turkey is now officially called "Türkiye".
Because we cannot have characters besides following pattern: A-Za-z0-9_ I replaced "ü" with "u".

Sources:
https://wikipedia.org/wiki/Turkey (Wikipedia)
https://www.bbc.co.uk/news/world-europe-61671913 (BBC News)
https://www.trtworld.com/turkey/un-to-use-t%C3%BCrkiye-instead-of-turkey-after-ankara-s-request-57633 (TRTWorld)
https://www.middleeasteye.net/news/turkey-turkiye-new-name-register-un-weeks (Middle East Eye)