### PR TITLE
Update names.txt

### DIFF
--- a/src/names/names.txt
+++ b/src/names/names.txt
@@ -984,6 +984,7 @@ Gavril
 Gayane
 Gayle
 Gaynor
+Gayu
 Gebhard
 Gemma
 Genadiy


### PR DESCRIPTION
Gayu als Vorname 1180mal vorhanden, als Nachname 555 mal vorhanden
https://forebears.io/search?q=gayu&meaning=genealogy-names-surnames

