### PR TITLE
Added "Neurodivergence" to nouns, as it is in the Oxford Dictionary.

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -863,6 +863,7 @@ negotiation
 nerve
 net
 network
+neurodivergence
 news
 newspaper
 night


### PR DESCRIPTION
Oxford Dictionary: https://www.oed.com/dictionary/neurodivergence_n?tl=true

Related Article: https://www.umassp.edu/inclusive-by-design/who-before-how/understanding-disabilities/neurodivergence

It is accepted as a noun in English. So why not?