### PR TITLE
Add "Janean" to names.txt

### DIFF
--- a/src/names/names.txt
+++ b/src/names/names.txt
@@ -1084,3 +1084,4 @@ Zaur
 Zoe
 Zoya
 Zu
+Janean


### PR DESCRIPTION
Janean is a feminine given name primarily used in the United States. 
It is considered a variation of the name "Jane" and has been in use since the mid-20th centu