### PR TITLE
chore: add "youthquake" to nouns.txt

### DIFF
--- a/src/words/google.txt
+++ b/src/words/google.txt
@@ -8603,7 +8603,7 @@ successful
 successfully
 such
 suck
-Sucked
+sucked
 sucking
 sucks
 sudan

--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1523,5 +1523,6 @@ yellow
 yesterday
 you
 youth
+youthquake
 zest
 zone

--- a/src/words/verbs.txt
+++ b/src/words/verbs.txt
@@ -39,9 +39,9 @@ appoint
 appreciate
 approach
 approve
-arouse
 argue
 arise
+arouse
 arrange
 arrest
 arrive


### PR DESCRIPTION
"Youthquake" is an established English noun meaning a significant cultural, political, or social shift initiated by young people. It was Oxford Dictionaries' Word of the Year 2017: https://languages.oup.com/word-of-the-year/2017/

This makes it a culturally relevant and recognized word, fitting into the OG names collection.