### PR TITLE
Add supremacy to nouns list

### DIFF
--- a/src/words/google.txt
+++ b/src/words/google.txt
@@ -1,3 +1,4 @@
+Sucked
 aa
 aaa
 aaron
@@ -8603,7 +8604,6 @@ successful
 successfully
 such
 suck
-Sucked
 sucking
 sucks
 sudan

--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1338,6 +1338,7 @@ suggestion
 suit
 summoner
 supermarket
+supremacy
 support
 surgery
 surprise

--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1338,8 +1338,8 @@ suggestion
 suit
 summoner
 supermarket
-supremacy
 support
+supremacy
 surgery
 surprise
 surround

--- a/src/words/verbs.txt
+++ b/src/words/verbs.txt
@@ -39,9 +39,9 @@ appoint
 appreciate
 approach
 approve
-arouse
 argue
 arise
+arouse
 arrange
 arrest
 arrive


### PR DESCRIPTION
Adding: supremacy

Reason:
"Supremacy" is an English noun meaning "the state or condition of being superior to all others."

Trusted source:
https://www.merriam-webster.com/dictionary/supremacy

Note:
also ran cleanup.py
