### PR TITLE
Added the name "Ghania" to the names list

### DIFF
--- a/src/names/names.txt
+++ b/src/names/names.txt
@@ -343,6 +343,7 @@ Gerrit
 Gerry
 Gert
 Gesa
+Ghania
 Gilbert
 Gill
 Gina

--- a/src/names/names.txt
+++ b/src/names/names.txt
@@ -189,6 +189,7 @@ Dani
 Daniel
 Danni
 Danny
+Dareen
 Darla
 Darlene
 Darrell


### PR DESCRIPTION
Ghania is an original Arabic given name meaning “graceful,” distinct from similarly spelled terms. Its identity as a personal name stands on its own.