### PR TITLE
Add 'unfindable' to adjectives list

### DIFF
--- a/src/words/adjectives.txt
+++ b/src/words/adjectives.txt
@@ -15,6 +15,7 @@ sentimental
 slender
 solitary
 tough
+unfindable
 vivid
 wealthy
 yum


### PR DESCRIPTION
Description
I am requesting the addition of the username "unfindable" to the `adjectives.txt` collection. 

justification
Legitimate Dictionary Word: It is an officially recognized, standalone adjective in major English dictionaries. It is not slang, a custom compound, or an ungrammatical phrase.

Commonly Understood:Unlike niche scientific vocabulary, "unfindable" is a universally recognized word known by the general public.

Clean In-Game Aesthetics: At 10 letters long, it features a clean structure with no numbers, underscores, or forced 
capitalization, making it highly visually appealing on scoreboards and chat.

Gaming/Minecraft Relevance: The definition heavily aligns with gaming culture, fitting common stealth, hidden, or elusive player aesthetics perfectly.

Sources
* https://www.merriam-webster.com/dictionary/unfindable
* https://www.collinsdictionary.com/dictionary/english/unfindable
* https://dictionary.cambridge.org/dictionary/english/unfindable

Thank you to the community and maintainers for reviewing this request!