### PR TITLE
Add uygur to nouns

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1,5 +1,4 @@
 MP15
-Uygur
 ability
 abroad
 abuse
@@ -1451,6 +1450,7 @@ use
 user
 usher
 usual
+uygur
 utopia
 vacation
 vale

--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1,4 +1,5 @@
 MP15
+Uygur
 ability
 abroad
 abuse


### PR DESCRIPTION
Request
Please add `uygur` to `src/words/nouns.txt`.

Why it fits
`Uygur` has its own English dictionary entry and is listed as both a noun and a proper noun. This PR uses the lowercase form `uygur` to match the style of the nouns list.

Source
- https://en.wiktionary.org/wiki/Uygur

Thanks for reviewing.