### PR TITLE
Adding noun "Telly"

### DIFF
--- a/src/words/nouns.txt
+++ b/src/words/nouns.txt
@@ -1372,6 +1372,7 @@ tear
 technology
 telephone
 television
+telly
 temperature
 temporary
 tennis


### PR DESCRIPTION
Common British English word meaning TV. https://www.merriam-webster.com/dictionary/telly https://dictionary.cambridge.org/dictionary/english/telly https://en.wiktionary.org/wiki/telly